### PR TITLE
Semi-http_open/3 compatible API

### DIFF
--- a/notes.org
+++ b/notes.org
@@ -1,0 +1,14 @@
+* New Architecture
+  Based around how ~http_open/3~ works with keep-alive.
+
+  Keep a pool of connections for the given host & port; each call to put/post/whatever checks if there's already a connection & re-uses that state.
+
+  I guess still allow setting headers to control caching?
+
+  Do we still have a worker thread?
+
+  Maybe have an option to either synchronously wait for the given request to finish or give a hook to run async?
+
+  Have the request thing return a fake stream & the client worker thread keeps a map of HTTP2 stream id to Prolog stream & can just write the decoded data as it goes?
+
+  I think compatibility with the ~http_open~ API would require it to be blocking per request though, to fill out the headers at least.

--- a/prolog/http2_client.pl
+++ b/prolog/http2_client.pl
@@ -71,7 +71,7 @@ default_close_cb(Data) :-
 http2_open(URL, Http2Ctx, Options) :-
     % Open TLS connection
     parse_url(URL, [protocol(https),host(Host)|Attrs]),
-    (memberchk(port(Port), Attrs) ; Port = 443), !,
+    ( memberchk(port(Port), Attrs) ; Port = 443 ), !,
     debug(http2_client(open), "URL ~w -> Host ~w:~w", [URL, Host, Port]),
     ssl_context(client, Ctx, [host(Host),
                               close_parent(true),
@@ -95,7 +95,7 @@ http2_open(URL, Http2Ctx, Options) :-
     send_frame(Stream, settings_frame([enable_push-0])),
     flush_output(Stream),
     % XXX: ...then we read a SETTINGS from from server & ACK it
-    (memberchk(close_cb(CloseCb), Options), ! ; CloseCb = default_close_cb),
+    ( memberchk(close_cb(CloseCb), Options), ! ; CloseCb = default_close_cb ),
     make_http2_state([authority(Host),
                       stream(Stream),
                       close_cb(CloseCb)],

--- a/prolog/simple_client.pl
+++ b/prolog/simple_client.pl
@@ -1,5 +1,8 @@
 :- module(simple_client, [http2_simple_open/3]).
 
+:- use_module(library(apply_macros)).
+:- use_module(library(apply), [convlist/3,
+                               maplist/3]).
 :- use_module(http2_client, [http2_close/1,
                              http2_open/3,
                              http2_request/4]).
@@ -44,17 +47,14 @@ canonical_header(Header, CanonicalHeader) :-
     re_replace("-"/g, "_", HeaderLower, CanonicalHeader).
 
 extract_headers(Options, Headers) :-
-    bagof(CKey-Value,
-          Key^( member(header(Key, Value), Options),
-            canonical_header(Key, CKey) ),
-         WantHeaders),
-    maplist({Headers}/[CKey-Value]>>(
-                ( member(Header-V, Headers),
-                  canonical_header(Header, CKey),
-                  Value = V
-                ) ; Value = ''
-            ),
-            WantHeaders).
+    convlist({Headers}/[header(Key, Value), _]>>(
+                 ( canonical_header(Key, CKey),
+                   member(Header-V, Headers),
+                   canonical_header(Header, CKey),
+                   Value = V
+                 ) ; Value = ''
+             ),
+             Options, _).
 
 build_options(_OpenOptions, []).
 

--- a/prolog/simple_client.pl
+++ b/prolog/simple_client.pl
@@ -91,6 +91,7 @@ http2_simple_close(URL) :-
     http2_close(Ctx).
 http2_simple_close(_).
 
+% Sample usage
 test :-
     debug(xxx),
     http2_simple_open('https://nghttp2.org/httpbin/ip',
@@ -107,5 +108,17 @@ test :-
     debug(xxx, "content len ~w", [ContentLen]),
     debug(xxx, "nonexistant header ~k", [Nope]),
     close(Stream),
-    %% http2_close(Ctx).
-    true.
+
+    % reusing the same connection
+    http2_simple_open('https://nghttp2.org/httpbin/headers', Stream2, []),
+    read_string(Stream2, _, Body2),
+    close(Body2),
+    debug(xxx, "headers body ~w", [Body2]),
+
+    % reusing the same connection
+    http2_simple_open('https://nghttp2.org/httpbin/get', Stream3, []),
+    read_string(Stream3, _, Body3),
+    close(Body3),
+    debug(xxx, "get body ~w", [Body3]),
+
+    http2_simple_close('https://nghttp2.org').

--- a/prolog/simple_client.pl
+++ b/prolog/simple_client.pl
@@ -108,31 +108,34 @@ http2_simple_close(_).
 % Sample usage
 test :-
     debug(xxx),
-    http2_simple_open('https://nghttp2.org/httpbin/ip',
+    http2_simple_open('https://occasionallycogent.com/entries.html',
                       Stream,
                       [headers(Headers),
                        header('Content-Length', ContentLen),
                        header(x_frame_options, FrameOpts),
-                       header(some_other_thing, Nope)
+                       header(some_other_thing, Nope),
+                       status_code(Status),
+                       size(Size)
                       ]),
-    read_string(Stream, _, Body),
+    read_string(Stream, 50, Body),
     debug(xxx, "body ~w", [Body]),
+    debug(xxx, "Status code ~w", [Status]),
     debug(xxx, "response headers ~w", [Headers]),
     debug(xxx, "Frame opts ~w", [FrameOpts]),
-    debug(xxx, "content len ~w", [ContentLen]),
+    debug(xxx, "content len ~w (= ~w)", [ContentLen, Size]),
     debug(xxx, "nonexistant header ~k", [Nope]),
     close(Stream),
 
     % reusing the same connection
-    http2_simple_open('https://nghttp2.org/httpbin/headers', Stream2, []),
-    read_string(Stream2, _, Body2),
-    close(Body2),
-    debug(xxx, "headers body ~w", [Body2]),
+    http2_simple_open('https://occasionallycogent.com/index.html', Stream2, []),
+    read_string(Stream2, 50, Body2),
+    close(Stream2),
+    debug(xxx, "index body ~w", [Body2]),
 
     % reusing the same connection
-    http2_simple_open('https://nghttp2.org/httpbin/get', Stream3, []),
-    read_string(Stream3, _, Body3),
-    close(Body3),
-    debug(xxx, "get body ~w", [Body3]),
+    http2_simple_open('https://occasionallycogent.com/about.html', Stream3, []),
+    read_string(Stream3, 50, Body3),
+    close(Stream3),
+    debug(xxx, "about body ~w", [Body3]),
 
     http2_simple_close('https://nghttp2.org').

--- a/prolog/simple_client.pl
+++ b/prolog/simple_client.pl
@@ -1,0 +1,57 @@
+:- module(simple_client, [http2_simple_open/4]).
+
+:- use_module(http2_client, [http2_close/1,
+                             http2_open/3,
+                             http2_request/4]).
+:- use_module(library(unix), [pipe/2]).
+:- use_module(library(url), [parse_url/2]).
+
+simple_complete_cb(OutStream, RespHeaders, RespHeaders, Body) :-
+    debug(xxx, "complete ~w ~w", [RespHeaders, Body]),
+    format(OutStream, "~s", [Body]),
+    close(OutStream).
+
+close_cb(Ctx, _Data) :-
+    debug(xxx, "closed", []).
+
+url_base_path(URL, Base, Path) :-
+    parse_url(URL, [protocol(Proto), host(Host)|URLAttrs]),
+    ( memberchk(port(PortN), URLAttrs)
+    -> format(string(Port), ":~w", [PortN])
+    ;  Port = ""
+    ),
+    format(string(Base), "~w://~w~w", [Proto, Host, Port]),
+    memberchk(path(Path_), URLAttrs),
+    ( memberchk(search(Search), URLAttrs)
+    -> ( parse_url_search(Qcs, Search),
+         format(string(Query), "?~s", [Qcs]) )
+    ;  Query = "" ),
+    ( memberchk(fragment(Frag), URLAttrs)
+    -> format(string(Fragment), "#~w", [Frag])
+    ;  Fragment = "" ),
+    atomic_list_concat([Path_, Query, Fragment], '', Path).
+
+http2_simple_open(Ctx, URL, Read, Options) :-
+    url_base_path(URL, BaseURL, Path),
+    debug(xxx, "opening ~w", [BaseURL]),
+    http2_open(BaseURL, Ctx, [close_cb(simple_client:close_cb(Ctx))]),
+    pipe(Read, Write),
+
+    ( memberchk(method(Meth), Options) ; Meth = get ),
+    ( memberchk(headers(RespHeaders), Options) ; RespHeaders = _ ),
+    string_upper(Meth, Method),
+    debug(xxx, "Requesting ~w ~w", [Method, Path]),
+    http2_request(Ctx, [':method'-Method, ':path'-Path|Opts],
+                  [],
+                  simple_complete_cb(Write, RespHeaders)).
+
+test :-
+    debug(xxx),
+    http2_simple_open(Ctx,
+                      'https://nghttp2.org/httpbin/ip',
+                      Stream,
+                      []),
+    read_string(Stream, _, Body),
+    debug(xxx, "body ~w", [Body]),
+    close(Stream),
+    http2_close(Ctx).

--- a/prolog/simple_client.pl
+++ b/prolog/simple_client.pl
@@ -1,14 +1,19 @@
-:- module(simple_client, [http2_simple_open/4]).
+:- module(simple_client, [http2_simple_open/3]).
 
 :- use_module(http2_client, [http2_close/1,
                              http2_open/3,
                              http2_request/4]).
 :- use_module(library(unix), [pipe/2]).
 :- use_module(library(url), [parse_url/2]).
+:- use_module(library(pcre), [re_replace/4]).
 
-simple_complete_cb(ThreadId, OutStream, Headers, Body) :-
+unwrap_header(Wrapped, Unwrapped) :-
+    Wrapped =.. [_, Unwrapped].
+
+simple_complete_cb(ThreadId, OutStream, WrappedHeaders, Body) :-
     format(OutStream, "~s", [Body]),
     close(OutStream),
+    maplist(unwrap_header, WrappedHeaders, Headers),
     thread_send_message(ThreadId, finished(Headers)).
 
 close_cb(_Ctx, _Data) :- true.
@@ -30,8 +35,28 @@ url_base_path(URL, Base, Path) :-
     ;  Fragment = "" ),
     atomic_list_concat([Path_, Query, Fragment], '', Path).
 
-http2_simple_open(Ctx, URL, Read, Options) :-
+canonical_header(Header, CanonicalHeader) :-
+    string_lower(Header, HeaderLower),
+    re_replace("-"/g, "_", HeaderLower, CanonicalHeader).
+
+extract_headers(Options, Headers) :-
+    bagof(CKey-Value,
+          Key^( member(header(Key, Value), Options),
+            canonical_header(Key, CKey) ),
+         WantHeaders),
+    maplist({Headers}/[CKey-Value]>>(
+                ( member(Header-V, Headers),
+                  canonical_header(Header, CKey),
+                  Value = V
+                ) ; Value = ''
+            ),
+            WantHeaders).
+
+build_options(_OpenOptions, []).
+
+http2_simple_open(URL, Read, Options) :-
     url_base_path(URL, BaseURL, Path),
+    % [TODO] keep conn open, cache?
     http2_open(BaseURL, Ctx, [close_cb(simple_client:close_cb(Ctx))]),
     pipe(Read, Write),
 
@@ -39,19 +64,31 @@ http2_simple_open(Ctx, URL, Read, Options) :-
     ( memberchk(headers(RespHeaders), Options) ; RespHeaders = _ ),
     string_upper(Meth, Method),
     thread_self(ThisId),
+
+    build_options(Options, Opts),
+
     http2_request(Ctx, [':method'-Method, ':path'-Path|Opts],
                   [],
                   simple_complete_cb(ThisId, Write)),
-    thread_get_message(finished(RespHeaders)).
+    thread_get_message(finished(RespHeaders)),
+    http2_close(Ctx), % [TODO]
+    extract_headers(Options, RespHeaders).
 
 test :-
     debug(xxx),
-    http2_simple_open(Ctx,
-                      'https://nghttp2.org/httpbin/ip',
+    http2_simple_open('https://nghttp2.org/httpbin/ip',
                       Stream,
-                      [headers(Headers)]),
+                      [headers(Headers),
+                       header('Content-Length', ContentLen),
+                       header(x_frame_options, FrameOpts),
+                       header(some_other_thing, Nope)
+                      ]),
     read_string(Stream, _, Body),
     debug(xxx, "body ~w", [Body]),
     debug(xxx, "response headers ~w", [Headers]),
+    debug(xxx, "Frame opts ~w", [FrameOpts]),
+    debug(xxx, "content len ~w", [ContentLen]),
+    debug(xxx, "nonexistant header ~k", [Nope]),
     close(Stream),
-    http2_close(Ctx).
+    %% http2_close(Ctx).
+    true.

--- a/prolog/simple_client.pl
+++ b/prolog/simple_client.pl
@@ -6,13 +6,12 @@
 :- use_module(library(unix), [pipe/2]).
 :- use_module(library(url), [parse_url/2]).
 
-simple_complete_cb(OutStream, RespHeaders, RespHeaders, Body) :-
-    debug(xxx, "complete ~w ~w", [RespHeaders, Body]),
+simple_complete_cb(ThreadId, OutStream, Headers, Body) :-
     format(OutStream, "~s", [Body]),
-    close(OutStream).
+    close(OutStream),
+    thread_send_message(ThreadId, finished(Headers)).
 
-close_cb(Ctx, _Data) :-
-    debug(xxx, "closed", []).
+close_cb(_Ctx, _Data) :- true.
 
 url_base_path(URL, Base, Path) :-
     parse_url(URL, [protocol(Proto), host(Host)|URLAttrs]),
@@ -33,25 +32,26 @@ url_base_path(URL, Base, Path) :-
 
 http2_simple_open(Ctx, URL, Read, Options) :-
     url_base_path(URL, BaseURL, Path),
-    debug(xxx, "opening ~w", [BaseURL]),
     http2_open(BaseURL, Ctx, [close_cb(simple_client:close_cb(Ctx))]),
     pipe(Read, Write),
 
     ( memberchk(method(Meth), Options) ; Meth = get ),
     ( memberchk(headers(RespHeaders), Options) ; RespHeaders = _ ),
     string_upper(Meth, Method),
-    debug(xxx, "Requesting ~w ~w", [Method, Path]),
+    thread_self(ThisId),
     http2_request(Ctx, [':method'-Method, ':path'-Path|Opts],
                   [],
-                  simple_complete_cb(Write, RespHeaders)).
+                  simple_complete_cb(ThisId, Write)),
+    thread_get_message(finished(RespHeaders)).
 
 test :-
     debug(xxx),
     http2_simple_open(Ctx,
                       'https://nghttp2.org/httpbin/ip',
                       Stream,
-                      []),
+                      [headers(Headers)]),
     read_string(Stream, _, Body),
     debug(xxx, "body ~w", [Body]),
+    debug(xxx, "response headers ~w", [Headers]),
     close(Stream),
     http2_close(Ctx).


### PR DESCRIPTION
The basic API of this library is very different from the standard library's `http_open/3`, making this hard to integrate. This PR represents an initial attempt to bridge that divide.